### PR TITLE
feat(#11): end-to-end integration tests

### DIFF
--- a/internal/decoy/handler.go
+++ b/internal/decoy/handler.go
@@ -1,6 +1,7 @@
 package decoy
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -72,6 +73,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to read request body", http.StatusInternalServerError)
 		return
 	}
+	// Restore body so assertion evaluators can read it.
+	r.Body = io.NopCloser(bytes.NewReader(body))
 
 	results := h.evaluator.Evaluate(r, requestID)
 	h.recorder.Record(results)

--- a/test/integration/admin_test.go
+++ b/test/integration/admin_test.go
@@ -1,0 +1,295 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdmin_HealthEndpoint(t *testing.T) {
+	configYAML := `
+assertions:
+  - name: dummy
+    description: "dummy"
+    severity: info
+    deny:
+      header: X-Never
+      condition: present
+`
+	_, _, adminURL := startDecoy(t, configYAML)
+
+	resp, err := http.Get(adminURL + "/__snitchproxy/health")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body map[string]string
+	err = json.NewDecoder(resp.Body).Decode(&body)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", body["status"])
+}
+
+func TestAdmin_ReportJSON(t *testing.T) {
+	configYAML := `
+assertions:
+  - name: no-auth
+    description: "No auth header"
+    severity: high
+    deny:
+      header: Authorization
+      condition: present
+`
+	_, modeURL, adminURL := startDecoy(t, configYAML)
+
+	// Send a violating request.
+	req, err := http.NewRequest("GET", modeURL+"/test", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer token")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	// Get JSON report.
+	reportResp, err := http.Get(adminURL + "/__snitchproxy/report")
+	require.NoError(t, err)
+	defer reportResp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, reportResp.StatusCode)
+	assert.Contains(t, reportResp.Header.Get("Content-Type"), "application/json")
+
+	var report struct {
+		TotalEvaluations int `json:"total_evaluations"`
+		ViolationCount   int `json:"violation_count"`
+		Violations       []struct {
+			Assertion   string `json:"assertion"`
+			Description string `json:"description"`
+			Severity    string `json:"severity"`
+			Detail      string `json:"detail"`
+			RequestID   string `json:"request_id"`
+		} `json:"violations"`
+	}
+	err = json.NewDecoder(reportResp.Body).Decode(&report)
+	require.NoError(t, err)
+
+	assert.GreaterOrEqual(t, report.TotalEvaluations, 1)
+	assert.Equal(t, 1, report.ViolationCount)
+	require.Len(t, report.Violations, 1)
+	assert.Equal(t, "no-auth", report.Violations[0].Assertion)
+	assert.Equal(t, "high", report.Violations[0].Severity)
+	assert.NotEmpty(t, report.Violations[0].RequestID)
+}
+
+func TestAdmin_ReportSARIF(t *testing.T) {
+	configYAML := `
+assertions:
+  - name: no-auth
+    description: "No auth header"
+    severity: high
+    deny:
+      header: Authorization
+      condition: present
+`
+	_, modeURL, adminURL := startDecoy(t, configYAML)
+
+	// Send a violating request.
+	req, err := http.NewRequest("GET", modeURL+"/test", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer token")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	// Get SARIF report.
+	reportResp, err := http.Get(adminURL + "/__snitchproxy/report?format=sarif")
+	require.NoError(t, err)
+	defer reportResp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, reportResp.StatusCode)
+	assert.Contains(t, reportResp.Header.Get("Content-Type"), "application/json")
+
+	var sarif struct {
+		Schema  string `json:"$schema"`
+		Version string `json:"version"`
+		Runs    []struct {
+			Tool struct {
+				Driver struct {
+					Name  string `json:"name"`
+					Rules []struct {
+						ID string `json:"id"`
+					} `json:"rules"`
+				} `json:"driver"`
+			} `json:"tool"`
+			Results []struct {
+				RuleID  string `json:"ruleId"`
+				Level   string `json:"level"`
+				Message struct {
+					Text string `json:"text"`
+				} `json:"message"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	err = json.NewDecoder(reportResp.Body).Decode(&sarif)
+	require.NoError(t, err)
+
+	assert.Equal(t, "2.1.0", sarif.Version)
+	require.Len(t, sarif.Runs, 1)
+	assert.Equal(t, "snitchproxy", sarif.Runs[0].Tool.Driver.Name)
+	require.Len(t, sarif.Runs[0].Results, 1)
+	assert.Equal(t, "no-auth", sarif.Runs[0].Results[0].RuleID)
+	assert.Equal(t, "error", sarif.Runs[0].Results[0].Level) // high -> error in SARIF
+}
+
+func TestAdmin_ReportJUnit(t *testing.T) {
+	configYAML := `
+assertions:
+  - name: no-auth
+    description: "No auth header"
+    severity: high
+    deny:
+      header: Authorization
+      condition: present
+`
+	_, modeURL, adminURL := startDecoy(t, configYAML)
+
+	// Send a violating request.
+	req, err := http.NewRequest("GET", modeURL+"/test", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer token")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	// Get JUnit report.
+	reportResp, err := http.Get(adminURL + "/__snitchproxy/report?format=junit")
+	require.NoError(t, err)
+	defer reportResp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, reportResp.StatusCode)
+	assert.Contains(t, reportResp.Header.Get("Content-Type"), "application/xml")
+
+	body, err := io.ReadAll(reportResp.Body)
+	require.NoError(t, err)
+
+	// Parse XML to verify structure.
+	var suites struct {
+		XMLName xml.Name `xml:"testsuites"`
+		Suites  []struct {
+			Name     string `xml:"name,attr"`
+			Tests    int    `xml:"tests,attr"`
+			Failures int    `xml:"failures,attr"`
+			Cases    []struct {
+				Name    string `xml:"name,attr"`
+				Failure *struct {
+					Message string `xml:"message,attr"`
+					Type    string `xml:"type,attr"`
+				} `xml:"failure"`
+			} `xml:"testcase"`
+		} `xml:"testsuite"`
+	}
+	err = xml.Unmarshal(body, &suites)
+	require.NoError(t, err)
+
+	require.Len(t, suites.Suites, 1)
+	assert.Equal(t, "snitchproxy", suites.Suites[0].Name)
+	assert.GreaterOrEqual(t, suites.Suites[0].Failures, 1)
+	require.NotEmpty(t, suites.Suites[0].Cases)
+
+	var found bool
+	for _, c := range suites.Suites[0].Cases {
+		if c.Name == "no-auth" {
+			found = true
+			require.NotNil(t, c.Failure)
+			assert.Equal(t, "high", c.Failure.Type)
+		}
+	}
+	assert.True(t, found, "expected test case for 'no-auth' assertion")
+}
+
+func TestAdmin_ResetClearsViolations(t *testing.T) {
+	configYAML := `
+assertions:
+  - name: no-auth
+    description: "No auth header"
+    severity: high
+    deny:
+      header: Authorization
+      condition: present
+`
+	sp, modeURL, adminURL := startDecoy(t, configYAML)
+
+	// Send a violating request.
+	req, err := http.NewRequest("GET", modeURL+"/test", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer token")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.Len(t, sp.Violations(), 1)
+
+	// POST /reset.
+	resetResp, err := http.Post(adminURL+"/__snitchproxy/reset", "", nil)
+	require.NoError(t, err)
+	defer resetResp.Body.Close()
+
+	assert.Equal(t, http.StatusNoContent, resetResp.StatusCode)
+
+	// Violations should be cleared.
+	assert.Empty(t, sp.Violations())
+
+	// Report should show zero violations.
+	reportResp, err := http.Get(adminURL + "/__snitchproxy/report")
+	require.NoError(t, err)
+	defer reportResp.Body.Close()
+
+	var report struct {
+		ViolationCount int `json:"violation_count"`
+	}
+	err = json.NewDecoder(reportResp.Body).Decode(&report)
+	require.NoError(t, err)
+	assert.Equal(t, 0, report.ViolationCount)
+}
+
+func TestAdmin_ConfigEndpoint(t *testing.T) {
+	configYAML := `
+presets:
+  - common-auth
+assertions: []
+`
+	_, _, adminURL := startDecoy(t, configYAML)
+
+	resp, err := http.Get(adminURL + "/__snitchproxy/config")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var assertions []struct {
+		Name    string `json:"name"`
+		Enabled bool   `json:"enabled"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&assertions)
+	require.NoError(t, err)
+
+	// common-auth preset should have expanded into multiple assertions.
+	assert.NotEmpty(t, assertions)
+
+	var found bool
+	for _, a := range assertions {
+		if a.Name == "common-auth/authorization-header" {
+			found = true
+			assert.True(t, a.Enabled)
+		}
+	}
+	assert.True(t, found, "expected common-auth/authorization-header in resolved config")
+}

--- a/test/integration/decoy_test.go
+++ b/test/integration/decoy_test.go
@@ -1,0 +1,220 @@
+package integration_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecoy_DenyAuthorizationHeader(t *testing.T) {
+	configYAML := `
+assertions:
+  - name: no-auth-header
+    description: "Authorization header must not be sent"
+    severity: high
+    deny:
+      header: Authorization
+      condition: present
+`
+	sp, modeURL, _ := startDecoy(t, configYAML)
+
+	req, err := http.NewRequest("GET", modeURL+"/api/test", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer secret-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Echo response should be 200 OK.
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Parse the echo response.
+	var echo map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&echo)
+	require.NoError(t, err)
+
+	assert.Equal(t, "GET", echo["method"])
+	assert.Equal(t, "/api/test", echo["path"])
+
+	// Verify violation was recorded.
+	violations := sp.Violations()
+	require.Len(t, violations, 1)
+	assert.Equal(t, "no-auth-header", violations[0].Assertion)
+	assert.Equal(t, "high", string(violations[0].Severity))
+}
+
+func TestDecoy_NoViolationWhenNoMatch(t *testing.T) {
+	configYAML := `
+assertions:
+  - name: no-auth-header
+    description: "Authorization header must not be sent"
+    severity: high
+    deny:
+      header: Authorization
+      condition: present
+`
+	sp, modeURL, _ := startDecoy(t, configYAML)
+
+	// Send request without Authorization header.
+	req, err := http.NewRequest("GET", modeURL+"/api/clean", nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// No violations should be recorded.
+	violations := sp.Violations()
+	assert.Empty(t, violations)
+}
+
+func TestDecoy_BodyPatternViolation(t *testing.T) {
+	configYAML := `
+assertions:
+  - name: no-secrets-in-body
+    description: "Request body must not contain secrets"
+    severity: critical
+    deny:
+      on: body
+      condition: matches
+      pattern: "secret_key=[A-Za-z0-9]+"
+`
+	sp, modeURL, _ := startDecoy(t, configYAML)
+
+	body := strings.NewReader("payload=data&secret_key=abc123XYZ")
+	req, err := http.NewRequest("POST", modeURL+"/api/data", body)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	violations := sp.Violations()
+	require.Len(t, violations, 1)
+	assert.Equal(t, "no-secrets-in-body", violations[0].Assertion)
+	assert.Equal(t, "critical", string(violations[0].Severity))
+}
+
+func TestDecoy_MultipleRequestsAccumulateViolations(t *testing.T) {
+	configYAML := `
+assertions:
+  - name: no-auth-header
+    description: "Authorization header must not be sent"
+    severity: high
+    deny:
+      header: Authorization
+      condition: present
+`
+	sp, modeURL, _ := startDecoy(t, configYAML)
+
+	// Send three requests with Authorization header.
+	for i := 0; i < 3; i++ {
+		req, err := http.NewRequest("GET", modeURL+"/api/test", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer token")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+	}
+
+	violations := sp.Violations()
+	assert.Len(t, violations, 3)
+	for _, v := range violations {
+		assert.Equal(t, "no-auth-header", v.Assertion)
+	}
+}
+
+func TestDecoy_EchoResponseContainsRequestDetails(t *testing.T) {
+	configYAML := `
+assertions:
+  - name: dummy
+    description: "dummy rule"
+    severity: info
+    deny:
+      header: X-Never-Sent
+      condition: present
+`
+	_, modeURL, _ := startDecoy(t, configYAML)
+
+	body := strings.NewReader("hello world")
+	req, err := http.NewRequest("POST", modeURL+"/api/echo?foo=bar", body)
+	require.NoError(t, err)
+	req.Header.Set("X-Custom", "test-value")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var echo struct {
+		RequestID string              `json:"request_id"`
+		Method    string              `json:"method"`
+		Path      string              `json:"path"`
+		Headers   map[string][]string `json:"headers"`
+		Body      string              `json:"body"`
+		Query     map[string][]string `json:"query"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&echo)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, echo.RequestID)
+	assert.Equal(t, "POST", echo.Method)
+	assert.Equal(t, "/api/echo", echo.Path)
+	assert.Equal(t, "hello world", echo.Body)
+	assert.Contains(t, echo.Headers["X-Custom"], "test-value")
+	assert.Contains(t, echo.Query["foo"], "bar")
+}
+
+func TestDecoy_AllowSemantics(t *testing.T) {
+	configYAML := `
+assertions:
+  - name: require-content-type
+    description: "Content-Type header must be present"
+    severity: warning
+    allow:
+      header: Content-Type
+      condition: present
+`
+	sp, modeURL, _ := startDecoy(t, configYAML)
+
+	// Send request WITHOUT Content-Type (should violate allow rule).
+	req, err := http.NewRequest("GET", modeURL+"/api/test", nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	violations := sp.Violations()
+	require.Len(t, violations, 1)
+	assert.Equal(t, "require-content-type", violations[0].Assertion)
+
+	// Reset and send request WITH Content-Type (should pass).
+	sp.Reset()
+	req2, err := http.NewRequest("POST", modeURL+"/api/test", strings.NewReader("data"))
+	require.NoError(t, err)
+	req2.Header.Set("Content-Type", "application/json")
+
+	resp2, err := http.DefaultClient.Do(req2)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+
+	assert.Empty(t, sp.Violations())
+}
+
+func getBody(t *testing.T, resp *http.Response) []byte {
+	t.Helper()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return body
+}

--- a/test/integration/failon_test.go
+++ b/test/integration/failon_test.go
@@ -1,0 +1,175 @@
+package integration_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vibewarden/snitchproxy/internal/assertion"
+)
+
+func TestFailOn_WarningViolationsBelowHighThreshold(t *testing.T) {
+	configYAML := `
+fail-on: high
+assertions:
+  - name: warn-rule
+    description: "Warning level rule"
+    severity: warning
+    deny:
+      header: X-Test
+      condition: present
+`
+	sp, modeURL, _ := startDecoy(t, configYAML)
+
+	// Send request that triggers the warning-level rule.
+	req, err := http.NewRequest("GET", modeURL+"/test", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Test", "value")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	// Violation exists.
+	require.Len(t, sp.Violations(), 1)
+
+	// HasViolationsAtOrAbove("high") should be false since only warning-level violation exists.
+	assert.False(t, sp.HasViolationsAtOrAbove(assertion.SeverityHigh),
+		"warning violation should not meet high threshold")
+
+	// HasViolationsAtOrAbove("warning") should be true.
+	assert.True(t, sp.HasViolationsAtOrAbove(assertion.SeverityWarning),
+		"warning violation should meet warning threshold")
+
+	// HasViolationsAtOrAbove("info") should be true.
+	assert.True(t, sp.HasViolationsAtOrAbove(assertion.SeverityInfo),
+		"warning violation should meet info threshold")
+}
+
+func TestFailOn_HighViolationMeetsHighThreshold(t *testing.T) {
+	configYAML := `
+fail-on: high
+assertions:
+  - name: high-rule
+    description: "High level rule"
+    severity: high
+    deny:
+      header: Authorization
+      condition: present
+`
+	sp, modeURL, _ := startDecoy(t, configYAML)
+
+	req, err := http.NewRequest("GET", modeURL+"/test", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer token")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.Len(t, sp.Violations(), 1)
+
+	assert.True(t, sp.HasViolationsAtOrAbove(assertion.SeverityHigh),
+		"high violation should meet high threshold")
+	assert.True(t, sp.HasViolationsAtOrAbove(assertion.SeverityWarning),
+		"high violation should meet warning threshold")
+	assert.False(t, sp.HasViolationsAtOrAbove(assertion.SeverityCritical),
+		"high violation should not meet critical threshold")
+}
+
+func TestFailOn_CriticalViolationMeetsAllThresholds(t *testing.T) {
+	configYAML := `
+assertions:
+  - name: critical-rule
+    description: "Critical level rule"
+    severity: critical
+    deny:
+      header: X-Secret
+      condition: present
+`
+	sp, modeURL, _ := startDecoy(t, configYAML)
+
+	req, err := http.NewRequest("GET", modeURL+"/test", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Secret", "value")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.Len(t, sp.Violations(), 1)
+
+	assert.True(t, sp.HasViolationsAtOrAbove(assertion.SeverityCritical))
+	assert.True(t, sp.HasViolationsAtOrAbove(assertion.SeverityHigh))
+	assert.True(t, sp.HasViolationsAtOrAbove(assertion.SeverityWarning))
+	assert.True(t, sp.HasViolationsAtOrAbove(assertion.SeverityInfo))
+}
+
+func TestFailOn_NoViolationsReturnsFalse(t *testing.T) {
+	configYAML := `
+assertions:
+  - name: no-match-rule
+    description: "This won't match"
+    severity: critical
+    deny:
+      header: X-Never-Sent
+      condition: present
+`
+	sp, modeURL, _ := startDecoy(t, configYAML)
+
+	// Send clean request.
+	req, err := http.NewRequest("GET", modeURL+"/test", nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Empty(t, sp.Violations())
+	assert.False(t, sp.HasViolationsAtOrAbove(assertion.SeverityInfo))
+}
+
+func TestFailOn_MixedSeverities(t *testing.T) {
+	configYAML := `
+assertions:
+  - name: info-rule
+    description: "Info level"
+    severity: info
+    deny:
+      header: X-Info
+      condition: present
+  - name: warning-rule
+    description: "Warning level"
+    severity: warning
+    deny:
+      header: X-Warning
+      condition: present
+`
+	sp, modeURL, _ := startDecoy(t, configYAML)
+
+	// Trigger only the info-level rule.
+	req, err := http.NewRequest("GET", modeURL+"/test", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Info", "yes")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.True(t, sp.HasViolationsAtOrAbove(assertion.SeverityInfo))
+	assert.False(t, sp.HasViolationsAtOrAbove(assertion.SeverityWarning))
+
+	// Now also trigger the warning-level rule.
+	req2, err := http.NewRequest("GET", modeURL+"/test", nil)
+	require.NoError(t, err)
+	req2.Header.Set("X-Warning", "yes")
+
+	resp2, err := http.DefaultClient.Do(req2)
+	require.NoError(t, err)
+	resp2.Body.Close()
+
+	assert.True(t, sp.HasViolationsAtOrAbove(assertion.SeverityWarning))
+	assert.False(t, sp.HasViolationsAtOrAbove(assertion.SeverityHigh))
+}

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -1,0 +1,148 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/vibewarden/snitchproxy/pkg/snitchproxy"
+)
+
+// startDecoy creates and starts a snitchproxy in decoy mode with the given config YAML.
+// Returns the SnitchProxy instance and the base URLs for mode and admin servers.
+func startDecoy(t *testing.T, configYAML string) (sp *snitchproxy.SnitchProxy, modeURL string, adminURL string) {
+	t.Helper()
+
+	sp, err := snitchproxy.New(
+		snitchproxy.WithConfigBytes([]byte(configYAML)),
+		snitchproxy.WithMode(snitchproxy.ModeDecoy),
+		snitchproxy.WithListenAddr(":0"),
+		snitchproxy.WithAdminAddr(":0"),
+	)
+	if err != nil {
+		t.Fatalf("creating decoy snitchproxy: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		cancel()
+		sp.Close()
+	})
+
+	if err := sp.Start(ctx); err != nil {
+		t.Fatalf("starting decoy snitchproxy: %v", err)
+	}
+
+	modeURL = fmt.Sprintf("http://%s", sp.ListenAddr())
+	adminURL = fmt.Sprintf("http://%s", sp.AdminAddr())
+	return sp, modeURL, adminURL
+}
+
+// startProxy creates and starts a snitchproxy in proxy mode with the given config YAML.
+// Returns the SnitchProxy instance and the mode/admin URLs.
+func startProxy(t *testing.T, configYAML string) (sp *snitchproxy.SnitchProxy, proxyURL string, adminURL string) {
+	t.Helper()
+
+	sp, err := snitchproxy.New(
+		snitchproxy.WithConfigBytes([]byte(configYAML)),
+		snitchproxy.WithMode(snitchproxy.ModeProxy),
+		snitchproxy.WithListenAddr(":0"),
+		snitchproxy.WithAdminAddr(":0"),
+	)
+	if err != nil {
+		t.Fatalf("creating proxy snitchproxy: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		cancel()
+		sp.Close()
+	})
+
+	if err := sp.Start(ctx); err != nil {
+		t.Fatalf("starting proxy snitchproxy: %v", err)
+	}
+
+	proxyURL = fmt.Sprintf("http://%s", sp.ListenAddr())
+	adminURL = fmt.Sprintf("http://%s", sp.AdminAddr())
+	return sp, proxyURL, adminURL
+}
+
+// recordedRequest stores a request received by the backend.
+type recordedRequest struct {
+	Method string
+	Path   string
+	Header http.Header
+	Body   string
+}
+
+// testBackend is a test HTTP server that records all requests.
+type testBackend struct {
+	Server   *httptest.Server
+	mu       sync.Mutex
+	requests []recordedRequest
+}
+
+// startBackend creates a test HTTP server that records requests and returns 200 OK.
+func startBackend(t *testing.T) *testBackend {
+	t.Helper()
+
+	tb := &testBackend{}
+	tb.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, 0)
+		if r.Body != nil {
+			var err error
+			body, err = readAll(r.Body)
+			if err != nil {
+				t.Errorf("backend: failed to read body: %v", err)
+			}
+		}
+
+		tb.mu.Lock()
+		tb.requests = append(tb.requests, recordedRequest{
+			Method: r.Method,
+			Path:   r.URL.Path,
+			Header: r.Header.Clone(),
+			Body:   string(body),
+		})
+		tb.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	}))
+	t.Cleanup(tb.Server.Close)
+
+	return tb
+}
+
+// Requests returns a copy of the recorded requests.
+func (tb *testBackend) Requests() []recordedRequest {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	out := make([]recordedRequest, len(tb.requests))
+	copy(out, tb.requests)
+	return out
+}
+
+// readAll reads all bytes from a reader, handling nil.
+func readAll(r interface{ Read([]byte) (int, error) }) ([]byte, error) {
+	var buf []byte
+	tmp := make([]byte, 1024)
+	for {
+		n, err := r.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+		}
+		if err != nil {
+			if err.Error() == "EOF" {
+				break
+			}
+			return buf, err
+		}
+	}
+	return buf, nil
+}

--- a/test/integration/preset_test.go
+++ b/test/integration/preset_test.go
@@ -1,0 +1,130 @@
+package integration_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreset_CommonAuthAuthorizationHeader(t *testing.T) {
+	configYAML := `
+presets:
+  - common-auth
+assertions: []
+`
+	sp, modeURL, _ := startDecoy(t, configYAML)
+
+	req, err := http.NewRequest("GET", modeURL+"/api/test", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer my-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	violations := sp.Violations()
+	// common-auth preset should flag the Authorization header.
+	var found bool
+	for _, v := range violations {
+		if v.Assertion == "common-auth/authorization-header" {
+			found = true
+			assert.Equal(t, "high", string(v.Severity))
+		}
+	}
+	assert.True(t, found, "expected common-auth/authorization-header violation, got violations: %v", violations)
+}
+
+func TestPreset_AWSKeysInBody(t *testing.T) {
+	configYAML := `
+presets:
+  - aws-keys
+assertions: []
+`
+	sp, modeURL, _ := startDecoy(t, configYAML)
+
+	// Send request body containing a fake AWS access key.
+	body := strings.NewReader(`{"access_key": "AKIAIOSFODNN7EXAMPLE"}`)
+	req, err := http.NewRequest("POST", modeURL+"/api/webhook", body)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	violations := sp.Violations()
+	var found bool
+	for _, v := range violations {
+		if v.Assertion == "aws-keys/access-key-in-body" {
+			found = true
+			assert.Equal(t, "critical", string(v.Severity))
+		}
+	}
+	assert.True(t, found, "expected aws-keys/access-key-in-body violation, got violations: %v", violations)
+}
+
+func TestPreset_PCIDSSCreditCardInBody(t *testing.T) {
+	configYAML := `
+presets:
+  - pci-dss
+assertions: []
+`
+	sp, modeURL, _ := startDecoy(t, configYAML)
+
+	// Send request body containing a test credit card number.
+	body := strings.NewReader(`{"card": "4111 1111 1111 1111"}`)
+	req, err := http.NewRequest("POST", modeURL+"/api/payment", body)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	violations := sp.Violations()
+	var found bool
+	for _, v := range violations {
+		if v.Assertion == "pci-dss/credit-card-in-body" {
+			found = true
+			assert.Equal(t, "critical", string(v.Severity))
+		}
+	}
+	assert.True(t, found, "expected pci-dss/credit-card-in-body violation, got violations: %v", violations)
+}
+
+func TestPreset_OverrideSeverity(t *testing.T) {
+	// Override the common-auth/authorization-header rule's severity from high to info.
+	configYAML := `
+presets:
+  - common-auth
+assertions:
+  - name: common-auth/authorization-header
+    description: "Authorization header present in outbound request"
+    severity: info
+    deny:
+      header: Authorization
+      condition: present
+`
+	sp, modeURL, _ := startDecoy(t, configYAML)
+
+	req, err := http.NewRequest("GET", modeURL+"/api/test", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer token")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	violations := sp.Violations()
+	var found bool
+	for _, v := range violations {
+		if v.Assertion == "common-auth/authorization-header" {
+			found = true
+			assert.Equal(t, "info", string(v.Severity), "severity should be overridden to info")
+		}
+	}
+	assert.True(t, found, "expected common-auth/authorization-header violation")
+}

--- a/test/integration/proxy_test.go
+++ b/test/integration/proxy_test.go
@@ -1,0 +1,142 @@
+package integration_test
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxy_ForwardsRequestToBackend(t *testing.T) {
+	backend := startBackend(t)
+
+	configYAML := `
+assertions:
+  - name: no-auth-header
+    description: "Authorization header must not be sent"
+    severity: high
+    deny:
+      header: Authorization
+      condition: present
+`
+	_, proxyURL, _ := startProxy(t, configYAML)
+
+	// Create HTTP client that uses the proxy.
+	proxyTransport := &http.Transport{
+		Proxy: func(_ *http.Request) (*url.URL, error) {
+			return url.Parse(proxyURL)
+		},
+	}
+	client := &http.Client{Transport: proxyTransport}
+
+	// Send request through proxy to backend (no violation).
+	req, err := http.NewRequest("GET", backend.Server.URL+"/api/data", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Trace", "test-trace")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Verify response came from backend.
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body := getBody(t, resp)
+	assert.Contains(t, string(body), `"status":"ok"`)
+
+	// Verify backend received the request.
+	reqs := backend.Requests()
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "GET", reqs[0].Method)
+	assert.Equal(t, "/api/data", reqs[0].Path)
+}
+
+func TestProxy_RecordsViolationAndStillForwards(t *testing.T) {
+	backend := startBackend(t)
+
+	configYAML := `
+assertions:
+  - name: no-auth-header
+    description: "Authorization header must not be sent"
+    severity: high
+    deny:
+      header: Authorization
+      condition: present
+`
+	sp, proxyURL, _ := startProxy(t, configYAML)
+
+	proxyTransport := &http.Transport{
+		Proxy: func(_ *http.Request) (*url.URL, error) {
+			return url.Parse(proxyURL)
+		},
+	}
+	client := &http.Client{Transport: proxyTransport}
+
+	// Send request with Authorization header (should trigger violation).
+	req, err := http.NewRequest("POST", backend.Server.URL+"/api/secret", strings.NewReader("payload"))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer leaked-token")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Request should still be forwarded successfully.
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Backend should have received the request.
+	reqs := backend.Requests()
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "POST", reqs[0].Method)
+	assert.Equal(t, "/api/secret", reqs[0].Path)
+
+	// Violation should be recorded.
+	violations := sp.Violations()
+	require.Len(t, violations, 1)
+	assert.Equal(t, "no-auth-header", violations[0].Assertion)
+	assert.Equal(t, "high", string(violations[0].Severity))
+}
+
+func TestProxy_BodyPatternViolationAndForward(t *testing.T) {
+	backend := startBackend(t)
+
+	configYAML := `
+assertions:
+  - name: no-secrets-in-body
+    description: "No secrets in body"
+    severity: critical
+    deny:
+      on: body
+      condition: matches
+      pattern: "password=[A-Za-z0-9]+"
+`
+	sp, proxyURL, _ := startProxy(t, configYAML)
+
+	proxyTransport := &http.Transport{
+		Proxy: func(_ *http.Request) (*url.URL, error) {
+			return url.Parse(proxyURL)
+		},
+	}
+	client := &http.Client{Transport: proxyTransport}
+
+	req, err := http.NewRequest("POST", backend.Server.URL+"/api/submit", strings.NewReader("user=alice&password=hunter2"))
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Backend received the request with body intact.
+	reqs := backend.Requests()
+	require.Len(t, reqs, 1)
+	assert.Contains(t, reqs[0].Body, "password=hunter2")
+
+	// Violation recorded.
+	violations := sp.Violations()
+	require.Len(t, violations, 1)
+	assert.Equal(t, "no-secrets-in-body", violations[0].Assertion)
+}


### PR DESCRIPTION
## Summary

- Add 22 end-to-end integration tests per ADR-11, organized into 5 test files: `decoy_test.go`, `proxy_test.go`, `preset_test.go`, `admin_test.go`, `failon_test.go`, plus shared helpers in `helpers_test.go`
- Fix a bug in the decoy handler where `r.Body` was consumed by `io.ReadAll` before assertion evaluation, preventing body-based conditions (matches, contains) from working in decoy mode
- All tests use the `pkg/snitchproxy` public API with `WithConfigBytes`, `WithMode`, `WithListenAddr(":0")`, `WithAdminAddr(":0")` for ephemeral port allocation

### Test coverage

| File | Tests | Scope |
|------|-------|-------|
| `decoy_test.go` | 6 | Deny/allow semantics, echo response, body patterns, accumulation |
| `proxy_test.go` | 3 | Request forwarding, violation recording, body inspection through proxy |
| `preset_test.go` | 4 | common-auth, aws-keys, pci-dss presets, severity override |
| `admin_test.go` | 6 | /health, /report (JSON/SARIF/JUnit), /reset, /config endpoints |
| `failon_test.go` | 5 | Severity threshold logic with mixed severity levels |

### Bug fix

`internal/decoy/handler.go`: The decoy handler read the request body but did not restore `r.Body` before passing the request to the assertion evaluator. This caused all body-based assertions to silently pass (empty body matched nothing). Fixed by restoring `r.Body` with `io.NopCloser(bytes.NewReader(body))` after reading, matching the pattern already used in the proxy handler.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all 22 new integration tests + existing tests)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)