### PR TITLE
Add CI pipeline with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ['1.22.x']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+      - run: go mod download
+      - run: go build ./...
+      - run: go vet ./...
+      - run: go test -race ./...
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.x'
+          cache: true
+      - name: Build binary
+        run: CGO_ENABLED=0 GOOS=linux go build -o snitchproxy ./cmd/snitchproxy
+      - uses: actions/upload-artifact@v4
+        with:
+          name: snitchproxy-linux
+          path: snitchproxy
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker build -t snitchproxy:ci .


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` implementing ADR-12 CI pipeline
- **Test job**: runs `go build`, `go vet`, and `go test -race` on Go 1.22.x / ubuntu-latest
- **Build job**: produces a static Linux binary (`CGO_ENABLED=0`) and uploads it as an artifact
- **Docker job**: verifies the Dockerfile builds successfully (main branch only)

Closes #12

## Test plan

- [ ] Verify CI workflow triggers on push to main
- [ ] Verify CI workflow triggers on pull requests to main
- [ ] Confirm test job runs all steps (mod download, build, vet, test)
- [ ] Confirm build job produces and uploads the binary artifact
- [ ] Confirm docker job runs only on main branch pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)