### PR TITLE
docs: set up MkDocs Material with GitHub Actions deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,32 @@
+name: Deploy docs to vibewarden.dev
+
+on:
+  push:
+    branches: [main]
+    paths: ["docs/**", "mkdocs.yml", ".github/workflows/docs.yml"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install mkdocs-material==9.5.* mkdocs-minify-plugin pymdown-extensions
+      - run: mkdocs build --strict --site-dir _site/docs
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          deploy_key: ${{ secrets.DOCS_DEPLOY_KEY }}
+          external_repository: vibewarden/vibewarden.dev
+          publish_branch: main
+          publish_dir: ./_site/docs
+          destination_dir: docs/snitchproxy
+          keep_files: true
+          commit_message: "docs: sync from vibewarden/snitchproxy@${{ github.sha }}"

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -1,0 +1,78 @@
+# Admin API
+
+SnitchProxy exposes an admin API on a separate port (default `:9484`) under the `/__snitchproxy/` path prefix.
+
+## Endpoints
+
+### Health check
+
+```
+GET /__snitchproxy/health
+```
+
+Returns `200 OK` with:
+
+```json
+{"status": "ok"}
+```
+
+Use this as a readiness probe for Docker/Testcontainers.
+
+### Violation report
+
+```
+GET /__snitchproxy/report
+GET /__snitchproxy/report?format=json
+GET /__snitchproxy/report?format=sarif
+GET /__snitchproxy/report?format=junit
+```
+
+Returns the current violation report. Default format is JSON.
+
+**JSON** (`application/json`):
+
+```json
+{
+  "total_evaluations": 42,
+  "violation_count": 2,
+  "violations": [
+    {
+      "assertion": "no-auth-to-analytics",
+      "description": "Never send credentials to analytics providers",
+      "severity": "critical",
+      "detail": "header \"Authorization\" is present",
+      "request_id": "req-7"
+    }
+  ]
+}
+```
+
+**SARIF** (`application/json`) — for GitHub Security tab integration:
+
+```bash
+curl http://localhost:9484/__snitchproxy/report?format=sarif > results.sarif
+# Upload to GitHub Security tab via github/codeql-action/upload-sarif
+```
+
+**JUnit XML** (`application/xml`) — for CI pipeline integration:
+
+```bash
+curl http://localhost:9484/__snitchproxy/report?format=junit > results.xml
+# Parse with your CI system's JUnit reporter
+```
+
+### Active configuration
+
+```
+GET /__snitchproxy/config
+```
+
+Returns the fully resolved assertion list (presets expanded, overrides applied) as a JSON array. Useful for debugging which rules are active.
+
+### Reset violations
+
+```
+POST /__snitchproxy/reset
+```
+
+Clears all collected violations and resets the evaluation counter. Returns `204 No Content`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,102 @@
+# Architecture
+
+## Package Structure
+
+```
+snitchproxy/
+├── cmd/snitchproxy/          # CLI entrypoint, flag parsing, wiring
+├── internal/
+│   ├── assertion/             # Assertion engine: matching, condition evaluation
+│   ├── config/                # YAML config parsing, validation, conversion
+│   ├── preset/                # Built-in rule packs (pci-dss, aws-keys, etc.)
+│   ├── proxy/                 # Transparent proxy mode handler
+│   ├── decoy/                 # Decoy endpoint mode handler
+│   ├── engine/                # Report accumulation (thread-safe)
+│   ├── admin/                 # Admin HTTP API
+│   └── report/                # Report formatters (JSON, SARIF, JUnit)
+├── pkg/snitchproxy/           # Public Go API for embedding
+└── test/integration/          # End-to-end tests
+```
+
+## Design Principles
+
+**Hexagonal-ish architecture.** The `engine` package defines ports (interfaces). `proxy`, `decoy`, `report`, and `admin` are adapters. `assertion` and `config` are domain logic.
+
+**Interfaces defined where consumed.** The `decoy` and `proxy` packages each define their own `Evaluator` and `Recorder` interfaces, satisfied by `assertion.Engine` and `engine.Report`.
+
+**No frameworks.** stdlib `net/http` for HTTP, `net/http/httputil` for proxying, `gopkg.in/yaml.v3` for config, `log/slog` for logging.
+
+**No global state.** No `init()` functions, no mutable package-level variables. Everything is wired via dependency injection with functional options.
+
+## Request Flow
+
+### Decoy Mode
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Decoy
+    participant Engine
+    participant Report
+
+    App->>Decoy: HTTP request
+    Decoy->>Decoy: Generate request ID
+    Decoy->>Decoy: Buffer body
+    Decoy->>Engine: Evaluate(request, ID)
+    Engine->>Engine: Match assertions
+    Engine->>Engine: Check conditions
+    Engine-->>Decoy: []Result
+    Decoy->>Report: Record(results)
+    Decoy-->>App: Echo response (JSON)
+```
+
+### Proxy Mode
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Proxy
+    participant Engine
+    participant Report
+    participant Upstream
+
+    App->>Proxy: HTTP request
+    Proxy->>Proxy: Generate request ID
+    Proxy->>Proxy: Buffer body
+    Proxy->>Engine: Evaluate(request, ID)
+    Engine-->>Proxy: []Result
+    Proxy->>Report: Record(results)
+    Proxy->>Upstream: Forward request
+    Upstream-->>Proxy: Response
+    Proxy-->>App: Response
+```
+
+## Assertion Evaluation Pipeline
+
+```
+Config YAML
+    │
+    ▼
+Load → Validate → Expand presets → Convert → Merge
+    │
+    ▼
+assertion.Engine (immutable after creation)
+    │
+    ▼
+Per-request: Match scope → Evaluate condition → Apply deny/allow → Result
+```
+
+1. **Match** — does the request match the assertion's scope (host, path, method, headers)?
+2. **Evaluate** — is the condition true (header present, body matches pattern, etc.)?
+3. **Invert** — for `deny`, condition true = violation. For `allow`, condition false = violation.
+
+## Severity Levels
+
+| Level | Rank | Typical use |
+|-------|------|-------------|
+| `critical` | 4 | Credential leaks, PCI violations |
+| `high` | 3 | Auth headers to wrong endpoints |
+| `warning` | 2 | PII in body, private IPs in headers |
+| `info` | 1 | Informational, non-blocking |
+
+The `fail-on` threshold controls the exit code: if any violation meets or exceeds the threshold, the process exits with code 1.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,107 @@
+# Configuration
+
+SnitchProxy is configured via a YAML file. The config defines which [presets](presets.md) to enable, custom [assertions](dsl-spec.md), and the failure threshold.
+
+## Config file location
+
+Provide the config via:
+
+- `--config` CLI flag: `snitchproxy --mode decoy --config snitchproxy.yaml`
+- `SNITCHPROXY_CONFIG` env var: file path or inline YAML
+- Docker mount: `-v $(pwd)/snitchproxy.yaml:/etc/snitchproxy/config.yaml`
+
+## Full example
+
+```yaml
+# snitchproxy.yaml — E-commerce API egress policy
+
+presets:
+  - common-auth
+  - pii
+
+fail-on: high
+
+assertions:
+  - name: no-internal-session
+    description: "Internal session tokens must never leave the network"
+    severity: critical
+    deny:
+      header: X-Internal-Session
+      condition: present
+
+  - name: no-auth-to-analytics
+    description: "Never send credentials to analytics providers"
+    severity: critical
+    match:
+      host:
+        - "*.analytics.google.com"
+        - "*.segment.io"
+        - "*.mixpanel.com"
+    deny:
+      header: Authorization
+      condition: present
+
+  - name: stripe-payment-hardening
+    description: "Stripe charge requests must use JSON over TLS 1.2+"
+    severity: critical
+    match:
+      host: "api.stripe.com"
+      path: "/v1/charges"
+      method: POST
+    allow:
+      all:
+        - header: Content-Type
+          condition: equals
+          value: "application/json"
+        - header: Idempotency-Key
+          condition: present
+        - on: tls
+          condition: version-gte
+          value: "1.2"
+```
+
+## Top-level fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `presets` | `string[]` | `[]` | Built-in rule packs to enable. See [Presets](presets.md). |
+| `fail-on` | `string` | `high` | Severity threshold. If any violation meets or exceeds this level, the process exits with code 1. One of: `critical`, `high`, `warning`, `info`. |
+| `assertions` | `object[]` | `[]` | Custom assertion rules. See [Assertion DSL](dsl-spec.md). |
+
+## Validation
+
+Config validation is strict and collects all errors at once (not fail-fast):
+
+- Each assertion must have a unique, non-empty `name`
+- Each assertion must have exactly one of `deny` or `allow` (not both)
+- `severity` must be one of: `critical`, `high`, `warning`, `info`
+- Conditions must be valid for their context (e.g., `in-cidr` only for `source-ip`)
+- `pattern` values must be valid regular expressions
+- `all` blocks must not be empty
+- Header context requires a `header` field
+- Query context requires a `param` field
+
+## Preset overrides
+
+User assertions can override preset rules by matching the preset rule name. For example, to disable a specific PCI-DSS rule:
+
+```yaml
+presets:
+  - pci-dss
+
+assertions:
+  - name: pci-dss/credit-card-in-query
+    enabled: false  # disable this specific preset rule
+```
+
+Or to change its severity:
+
+```yaml
+assertions:
+  - name: pci-dss/credit-card-in-body
+    severity: warning  # downgrade from high to warning
+    deny:
+      on: body
+      condition: matches
+      pattern: '\b\d{13,19}\b'
+```

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1,0 +1,101 @@
+# Embedding
+
+SnitchProxy can be embedded directly in your Go tests via the `pkg/snitchproxy` package.
+
+## Installation
+
+```bash
+go get github.com/vibewarden/snitchproxy
+```
+
+## Usage
+
+```go
+package myapp_test
+
+import (
+    "context"
+    "net/http"
+    "testing"
+
+    "github.com/vibewarden/snitchproxy/pkg/snitchproxy"
+)
+
+func TestEgressSecurity(t *testing.T) {
+    sp, err := snitchproxy.New(
+        snitchproxy.WithConfigBytes([]byte(`
+presets:
+  - common-auth
+  - pii
+fail-on: high
+`)),
+        snitchproxy.WithMode(snitchproxy.ModeDecoy),
+        snitchproxy.WithListenAddr(":0"),
+        snitchproxy.WithAdminAddr(":0"),
+    )
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if err := sp.Start(context.Background()); err != nil {
+        t.Fatal(err)
+    }
+    defer sp.Close()
+
+    // Point your HTTP client at sp.ListenAddr()
+    resp, err := http.Get("http://" + sp.ListenAddr() + "/api/data")
+    if err != nil {
+        t.Fatal(err)
+    }
+    resp.Body.Close()
+
+    // Check for violations
+    if sp.HasViolationsAtOrAbove("high") {
+        for _, v := range sp.Violations() {
+            t.Errorf("violation: %s — %s", v.Assertion, v.Detail)
+        }
+    }
+}
+```
+
+## API Reference
+
+### `New(opts ...Option) (*SnitchProxy, error)`
+
+Creates a new SnitchProxy instance. Applies options, loads config, validates, expands presets, and prepares the assertion engine.
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `WithConfigFile(path)` | Load config from a YAML file |
+| `WithConfigBytes(data)` | Load config from inline YAML bytes |
+| `WithMode(mode)` | Set operating mode (`ModeDecoy` or `ModeProxy`) |
+| `WithListenAddr(addr)` | Set proxy/decoy listen address (default `:8080`, use `:0` for random) |
+| `WithAdminAddr(addr)` | Set admin API listen address (default `:9484`, use `:0` for random) |
+| `WithFailOn(severity)` | Override the `fail-on` threshold from config |
+| `WithLogger(logger)` | Set a custom `*slog.Logger` |
+
+### `Start(ctx context.Context) error`
+
+Starts both the mode server and admin server. Use `:0` addresses for ephemeral ports in tests. The context controls the server lifecycle — when cancelled, servers shut down gracefully.
+
+### `Close() error`
+
+Performs graceful shutdown of both servers with a 10-second timeout.
+
+### `Violations() []assertion.Violation`
+
+Returns all violations collected so far.
+
+### `HasViolationsAtOrAbove(severity) bool`
+
+Returns true if any violation meets or exceeds the given severity level.
+
+### `Reset()`
+
+Clears all collected violations.
+
+### `ListenAddr() string` / `AdminAddr() string`
+
+Returns the actual bound addresses. Useful when using `:0` for random port assignment.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,97 @@
+# Getting Started
+
+## Installation
+
+### Binary
+
+```bash
+go install github.com/vibewarden/snitchproxy/cmd/snitchproxy@latest
+```
+
+### Docker
+
+```bash
+docker pull ghcr.io/vibewarden/snitchproxy:latest
+```
+
+## Quick Start
+
+### 1. Create a config file
+
+Create `snitchproxy.yaml`:
+
+```yaml
+presets:
+  - common-auth
+  - pii
+
+fail-on: high
+
+assertions:
+  - name: no-auth-to-analytics
+    description: "Never send credentials to analytics providers"
+    severity: critical
+    match:
+      host:
+        - "*.analytics.google.com"
+        - "*.segment.io"
+    deny:
+      header: Authorization
+      condition: present
+```
+
+### 2. Run in decoy mode
+
+Decoy mode is the easiest way to start. It creates a fake API endpoint that echoes requests back while checking them against your assertions.
+
+```bash
+snitchproxy --mode decoy --config snitchproxy.yaml
+```
+
+Point your app at `http://localhost:8080` instead of the real external API. Every request is echoed back as JSON and evaluated against your assertions.
+
+### 3. Run in proxy mode
+
+Proxy mode forwards traffic to real destinations while inspecting it.
+
+```bash
+snitchproxy --mode proxy --config snitchproxy.yaml
+```
+
+Configure your app to use `http://localhost:8080` as its HTTP proxy.
+
+### 4. Check results
+
+Query the admin API for violations:
+
+```bash
+# JSON report
+curl http://localhost:9484/__snitchproxy/report
+
+# SARIF format (GitHub Security tab)
+curl http://localhost:9484/__snitchproxy/report?format=sarif
+
+# JUnit format (CI pipelines)
+curl http://localhost:9484/__snitchproxy/report?format=junit
+```
+
+### 5. Docker
+
+```bash
+docker run -p 8080:8080 -p 9484:9484 \
+  -v $(pwd)/snitchproxy.yaml:/etc/snitchproxy/config.yaml \
+  ghcr.io/vibewarden/snitchproxy --mode decoy
+```
+
+## CLI Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--mode` | *(required)* | `proxy` or `decoy` |
+| `--config` | — | Path to YAML config file |
+| `--listen` | `:8080` | Proxy/decoy listen address |
+| `--admin` | `:9484` | Admin API listen address |
+| `--fail-on` | config value | Severity threshold for exit code 1 |
+| `--version` | — | Print version and exit |
+
+The config file can also be provided via the `SNITCHPROXY_CONFIG` environment variable (either a file path or inline YAML).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,31 @@
+# SnitchProxy
+
+**Egress security scanner — catch data leaks before they leave your app.**
+
+SnitchProxy is a dual-mode egress security testing tool. Deploy it as a **fake external API** to catch credential leaks, or as a **transparent proxy** to audit real integration traffic. Either way, it snitches on your app when sensitive data tries to escape.
+
+## The Problem
+
+Every security tool today tests *inbound* traffic — is your server safe from attackers? Nobody tests *outbound* traffic — is your app safe to connect to? Apps routinely leak credentials, session tokens, PII, and internal headers to third-party APIs. There's no standard tool to catch this.
+
+## How It Works
+
+**Mode 1 — Decoy Endpoint** (like httpbin with teeth):
+
+1. Point your app at SnitchProxy instead of a real external API
+2. SnitchProxy echoes every request AND evaluates it against your assertions
+3. Violations are collected and reported via the admin API
+
+**Mode 2 — Transparent Proxy** (like Toxiproxy for security):
+
+1. Route your app's outbound traffic through SnitchProxy
+2. Traffic flows to real external APIs, but SnitchProxy inspects everything
+3. Violations are reported via the admin API and final report
+
+## Part of the VibeWarden Ecosystem
+
+| Tool | Role |
+|------|------|
+| [VibeWarden](https://vibewarden.dev/docs) | Egress proxy — the lock |
+| **SnitchProxy** | Egress assertion engine — the lock tester |
+| [httptape](https://github.com/vibewarden/httptape) | Request recorder — the evidence |

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -1,0 +1,81 @@
+# Presets
+
+Presets are built-in rule packs that detect common data leak patterns. Enable them in your config with the `presets` field.
+
+```yaml
+presets:
+  - common-auth
+  - pii
+  - pci-dss
+```
+
+## Available Presets
+
+### `common-auth`
+
+Detects leaked authentication credentials.
+
+| Rule | Severity | What it catches |
+|------|----------|----------------|
+| `common-auth/authorization-header` | high | `Authorization` header present |
+| `common-auth/cookie-header` | high | `Cookie` header present |
+| `common-auth/x-api-key-header` | high | `X-API-Key` header present |
+| `common-auth/bearer-in-body` | high | Bearer tokens in request body |
+| `common-auth/set-cookie-header` | high | `Set-Cookie` header present |
+
+### `pii`
+
+Detects personally identifiable information in request bodies.
+
+| Rule | Severity | What it catches |
+|------|----------|----------------|
+| `pii/ssn-in-body` | critical | Social Security Numbers |
+| `pii/email-in-body` | warning | Email addresses |
+| `pii/phone-in-body` | warning | Phone numbers |
+| `pii/dob-in-body` | warning | Dates of birth |
+
+### `pci-dss`
+
+Detects payment card data (PCI DSS compliance).
+
+| Rule | Severity | What it catches |
+|------|----------|----------------|
+| `pci-dss/credit-card-in-body` | critical | Credit card numbers in body |
+| `pci-dss/credit-card-in-query` | critical | Credit card numbers in query strings |
+| `pci-dss/track-data-in-body` | critical | Magnetic stripe track data |
+| `pci-dss/cvv-in-body` | critical | CVV/CVC codes |
+
+### `aws-keys`
+
+Detects leaked AWS credentials.
+
+| Rule | Severity | What it catches |
+|------|----------|----------------|
+| `aws-keys/access-key-in-body` | critical | `AKIA*` access keys in body |
+| `aws-keys/access-key-in-query` | critical | `AKIA*` access keys in query |
+| `aws-keys/secret-key-in-body` | critical | AWS secret keys in body |
+| `aws-keys/sts-token-in-body` | high | STS session tokens in body |
+
+### `gcp-keys`
+
+Detects leaked GCP credentials.
+
+| Rule | Severity | What it catches |
+|------|----------|----------------|
+| `gcp-keys/api-key-in-body` | critical | GCP API keys in body |
+| `gcp-keys/api-key-in-query` | critical | GCP API keys in query |
+| `gcp-keys/service-account-in-body` | critical | Service account JSON fragments |
+
+### `private-net`
+
+Detects internal network information leaking in headers.
+
+| Rule | Severity | What it catches |
+|------|----------|----------------|
+| `private-net/rfc1918-in-x-forwarded-for` | warning | RFC 1918 IPs in `X-Forwarded-For` |
+| `private-net/rfc1918-in-x-real-ip` | warning | RFC 1918 IPs in `X-Real-IP` |
+| `private-net/rfc1918-in-host` | warning | RFC 1918 IPs in `Host` header |
+
+## Overriding Preset Rules
+
+You can override any preset rule by creating a custom assertion with the same name. See [Configuration](configuration.md#preset-overrides) for details.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,74 @@
+site_name: SnitchProxy
+site_description: Egress security scanner — catch data leaks before they leave your app.
+site_url: https://vibewarden.dev/docs/snitchproxy
+repo_url: https://github.com/vibewarden/snitchproxy
+repo_name: vibewarden/snitchproxy
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: cyan
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: cyan
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+    - toc.follow
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Configuration: configuration.md
+  - Assertion DSL: dsl-spec.md
+  - Presets: presets.md
+  - Admin API: admin-api.md
+  - Embedding: embedding.md
+  - Architecture: architecture.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/vibewarden/snitchproxy


### PR DESCRIPTION
## Summary
- MkDocs Material config matching vibewarden.dev theme (deep purple/cyan, dark mode toggle)
- 7 documentation pages: home, getting started, configuration, presets, admin API, embedding, architecture
- GitHub Actions workflow deploying to `vibewarden.dev/docs/snitchproxy` via deploy key
- Existing `docs/dsl-spec.md` included in nav

## Pages
| Page | Content |
|------|---------|
| Home | Project overview, problem statement, how it works |
| Getting Started | Install, quick start (decoy/proxy), CLI flags |
| Configuration | Full config reference, validation rules, preset overrides |
| Presets | All 6 presets with rule tables (23 rules) |
| Admin API | All endpoints with request/response examples |
| Embedding | Go API reference with test example |
| Architecture | Package structure, design principles, mermaid sequence diagrams |

## Setup required
The `DOCS_DEPLOY_KEY` secret needs to be configured with write access to `vibewarden/vibewarden.dev`. Same key used by the vibewarden repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)