### PR TITLE
docs: add STATUS.md marking project as parked

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,12 @@
+# Project Status
+
+**Parked** — last active 2026-04-17.
+
+The engineering is at a clean resting point: public API, CI, integration tests, and MkDocs site are all in place. Further investment is paused pending external signal.
+
+## What would unpark it
+
+- VibeWarden integration work pulls on the assertion engine or presets, revealing the real shape needed.
+- A user materializes with a concrete egress-leak testing problem that snitchproxy fits better than mitmproxy + script or wiremock + matchers.
+
+Until then, no new features. Bug fixes and dependency updates only.


### PR DESCRIPTION
## Summary
- Adds `STATUS.md` recording that snitchproxy is paused at a clean resting point
- Documents the conditions under which work would resume (VibeWarden integration or external user signal)
- Avoids future ambiguity about whether the project is actively maintained

## Test plan
- [x] File renders correctly on GitHub